### PR TITLE
composite keys support

### DIFF
--- a/src/Request/DeleteRequest.php
+++ b/src/Request/DeleteRequest.php
@@ -10,11 +10,11 @@ class DeleteRequest implements Request
     private $indexId;
     private $key;
 
-    public function __construct($spaceId, $indexId, array $key)
+    public function __construct($spaceId, $indexId, $key)
     {
         $this->spaceId = $spaceId;
         $this->indexId = $indexId;
-        $this->key = $key;
+        $this->key = (array) $key;
     }
 
     public function getType()

--- a/src/Request/SelectRequest.php
+++ b/src/Request/SelectRequest.php
@@ -13,11 +13,11 @@ class SelectRequest implements Request
     private $limit;
     private $iterator;
 
-    public function __construct($spaceId, $indexId, array $key, $offset, $limit, $iterator)
+    public function __construct($spaceId, $indexId, $key, $offset, $limit, $iterator)
     {
         $this->spaceId = $spaceId;
         $this->indexId = $indexId;
-        $this->key = $key;
+        $this->key = (array) $key;
         $this->offset = $offset;
         $this->limit = $limit;
         $this->iterator = $iterator;

--- a/src/Request/UpdateRequest.php
+++ b/src/Request/UpdateRequest.php
@@ -15,7 +15,7 @@ class UpdateRequest implements Request
     {
         $this->spaceId = $spaceId;
         $this->indexId = $indexId;
-        $this->key = $key;
+        $this->key = (array) $key;
         $this->operations = $operations;
     }
 
@@ -29,7 +29,7 @@ class UpdateRequest implements Request
         return [
             IProto::SPACE_ID => $this->spaceId,
             IProto::INDEX_ID => $this->indexId,
-            IProto::KEY => [$this->key],
+            IProto::KEY => $this->key,
             IProto::TUPLE => $this->operations,
         ];
     }

--- a/tests/Integration/SpaceTest.php
+++ b/tests/Integration/SpaceTest.php
@@ -300,4 +300,18 @@ class SpaceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(4, Utils::getTotalSelectCalls() - $total);
     }
+
+    public function testCompositeKeys()
+    {
+        $space = self::$client->getSpace('space_composite');
+        $this->assertSame(1, $space->select([2016, 10])->getData()[0][2]);
+        $this->assertSame(0, $space->select([2016, 11])->getData()[0][2]);
+
+        $space->update([2016, 10], [['=', 2, 0]]);
+        $this->assertSame(0, $space->select([2016, 10])->getData()[0][2]);
+
+        $space->delete([2016, 11]);
+        $this->assertCount(0, $space->select([2016, 11])->getData());
+        $this->assertCount(1, $space->select([2016])->getData());
+    }
 }

--- a/tests/Integration/client.lua
+++ b/tests/Integration/client.lua
@@ -74,6 +74,11 @@ function create_fixtures()
     for i = 1, 100 do
         space:replace{i, i * 2 % 5, 'tuple_' .. i}
     end
+
+    space = create_space('space_composite')
+    space:create_index('primary', {type = 'tree', unique = true, parts = {1, 'num', 2, 'num'}})
+    space:insert{2016, 10, 1}
+    space:insert{2016, 11, 0}
 end
 
 function func_foo()


### PR DESCRIPTION
UpdateRequest implementation contains array wrapper for the primary key.
In this case, i unable to make an update of the tuple with composite key.

I added the check, to keep backward compatibility.
