### PR TITLE
[Client] add closeConnection method.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 .phpunit.result.cache
 composer.lock
 phpunit.xml
+.idea/

--- a/src/Client.php
+++ b/src/Client.php
@@ -193,6 +193,15 @@ final class Client
         $this->spaces = [];
     }
 
+    public function closeConnection() : void
+    {
+        $conn = $this->handler->getConnection();
+        if (!$conn) {
+            return;
+        }
+        $conn->close();
+    }
+
     private function getSpaceIdByName(string $spaceName) : int
     {
         $schema = $this->getSpaceById(Space::VSPACE_ID);


### PR DESCRIPTION
Subj. I got some strange behavior that is not handled by library.
I have connection, then block it via firewall, then unblock and I receive something like 'Unable to read response.'
This option allows to stop connection from Client API and reopen it when the next 'call' comes.