### PR TITLE
added feature to set socket timeout as float

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /composer.lock
 /coverage*
 /phpunit.xml
+/.idea

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ The following options are available:
 Name | Type | Default | Description
 --- | :---: | :---: | ---
 *uri* | string | 'tcp://127.0.0.1:3301' | The connection uri that is used to create a `StreamConnection` object.
-*connect_timeout* | integer | 5 | The number of seconds that the client waits for a connect to a Tarantool server before throwing a `ConnectionFailed` exception.
-*socket_timeout* | integer | 5 | The number of seconds that the client waits for a respond from a Tarantool server before throwing a `CommunicationFailed` exception.
+*connect_timeout* | float | 5 | The number of seconds that the client waits for a connect to a Tarantool server before throwing a `ConnectionFailed` exception.
+*socket_timeout* | float | 5 | The number of seconds that the client waits for a respond from a Tarantool server before throwing a `CommunicationFailed` exception.
 *tcp_nodelay* | boolean | true | Whether the Nagle algorithm is disabled on a TCP connection.
 *persistent* | boolean | false | Whether to use a persistent connection.
 *username* | string | | The username for the user being authenticated.

--- a/src/Client.php
+++ b/src/Client.php
@@ -89,10 +89,10 @@ final class Client
         $dsn = Dsn::parse($dsn);
 
         $connectionOptions = [];
-        if (null !== $timeout = $dsn->getInt('connect_timeout')) {
+        if (null !== $timeout = $dsn->getFloat('connect_timeout')) {
             $connectionOptions['connect_timeout'] = $timeout;
         }
-        if (null !== $timeout = $dsn->getInt('socket_timeout')) {
+        if (null !== $timeout = $dsn->getFloat('socket_timeout')) {
             $connectionOptions['socket_timeout'] = $timeout;
         }
         if (null !== $tcpNoDelay = $dsn->getBool('tcp_nodelay')) {

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -107,9 +107,9 @@ final class StreamConnection implements Connection
 
         $this->stream = $stream;
         $socketTimeoutMicroseconds = 0;
-        $socketTimeoutSeconds = (int)($this->options['socket_timeout']);
-        if (is_float($this->options['socket_timeout'])) {
-            $socketTimeoutMicroseconds = (int)($this->options['socket_timeout'] * 1000000);
+        $socketTimeoutSeconds = (int) ($this->options['socket_timeout']);
+        if (\is_float($this->options['socket_timeout'])) {
+            $socketTimeoutMicroseconds = (int) ($this->options['socket_timeout'] * 1000000);
             $socketTimeoutMicroseconds -= $socketTimeoutSeconds * 1000000;
         }
         \stream_set_timeout($this->stream, $socketTimeoutSeconds, $socketTimeoutMicroseconds);

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -107,12 +107,12 @@ final class StreamConnection implements Connection
 
         $this->stream = $stream;
         $socketTimeoutMicroseconds = 0;
+        $socketTimeoutSeconds = (int)($this->options['socket_timeout']);
         if (is_float($this->options['socket_timeout'])) {
             $socketTimeoutMicroseconds = (int)($this->options['socket_timeout'] * 1000000);
-            $this->options['socket_timeout'] = (int)($this->options['socket_timeout']);
-            $socketTimeoutMicroseconds -= $this->options['socket_timeout'] * 1000000;
+            $socketTimeoutMicroseconds -= $socketTimeoutSeconds * 1000000;
         }
-        \stream_set_timeout($this->stream, $this->options['socket_timeout'], $socketTimeoutMicroseconds);
+        \stream_set_timeout($this->stream, $socketTimeoutSeconds, $socketTimeoutMicroseconds);
 
         if ($this->options['persistent'] && \ftell($this->stream)) {
             return $this->greeting = Greeting::unknown();

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -106,7 +106,13 @@ final class StreamConnection implements Connection
         }
 
         $this->stream = $stream;
-        \stream_set_timeout($this->stream, $this->options['socket_timeout']);
+        $socketTimeoutMicroseconds = 0;
+        if (is_float($this->options['socket_timeout'])) {
+            $socketTimeoutMicroseconds = (int)($this->options['socket_timeout'] * 1000000);
+            $this->options['socket_timeout'] = (int)($this->options['socket_timeout']);
+            $socketTimeoutMicroseconds -= $this->options['socket_timeout'] * 1000000;
+        }
+        \stream_set_timeout($this->stream, $this->options['socket_timeout'], $socketTimeoutMicroseconds);
 
         if ($this->options['persistent'] && \ftell($this->stream)) {
             return $this->greeting = Greeting::unknown();

--- a/src/Dsn.php
+++ b/src/Dsn.php
@@ -181,6 +181,19 @@ final class Dsn
         return $value;
     }
 
+    public function getFloat(string $name, ?float $default = null) : ?float
+    {
+        if (!isset($this->options[$name])) {
+            return $default;
+        }
+
+        if (false === $value = \filter_var($this->options[$name], \FILTER_VALIDATE_FLOAT)) {
+            throw new \TypeError(\sprintf('DSN option "%s" must be of the type float', $name));
+        }
+
+        return $value;
+    }
+
     /**
      * @psalm-return never-returns
      */

--- a/tests/Unit/DsnTest.php
+++ b/tests/Unit/DsnTest.php
@@ -216,10 +216,10 @@ final class DsnTest extends TestCase
     public function provideFloatOptions() : iterable
     {
         return [
-            ['tcp://host/?foo=42.1', 'foo', 42.1],
+            ['tcp://host/?foo=4.2', 'foo', 4.2],
             ['tcp://host/?foo=0', 'foo', 0.0],
             ['tcp://host', 'foo', null],
-            ['unix:///socket.sock/?foo=42.1', 'foo', 42.1],
+            ['unix:///socket.sock/?foo=4.2', 'foo', 4.2],
             ['unix:///socket.sock/?foo=0', 'foo', 0.0],
             ['unix:///socket.sock', 'foo', null],
         ];
@@ -228,7 +228,7 @@ final class DsnTest extends TestCase
     public function testGetFloatDefault() : void
     {
         $dsn = Dsn::parse('tcp://host/?foo=2.2');
-        self::assertSame(42.1, $dsn->getFloat('baz', 42.1));
+        self::assertSame(4.2, $dsn->getFloat('baz', 4.2));
     }
 
     /**

--- a/tests/Unit/DsnTest.php
+++ b/tests/Unit/DsnTest.php
@@ -232,6 +232,30 @@ final class DsnTest extends TestCase
     }
 
     /**
+     * @dataProvider provideNonFloatOptions
+     */
+    public function testGetNonFloat(string $dsn, string $option) : void
+    {
+        $dsn = Dsn::parse($dsn);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('DSN option "foo" must be of the type float');
+        $dsn->getFloat($option);
+    }
+
+    public function provideNonFloatOptions() : iterable
+    {
+        return [
+            ['tcp://host/?foo=bar', 'foo'],
+            ['tcp://host/?foo=true', 'foo'],
+            ['tcp://host/?foo=', 'foo'],
+            ['unix:///socket.sock/?foo=bar', 'foo'],
+            ['unix:///socket.sock/?foo=true', 'foo'],
+            ['unix:///socket.sock/?foo=', 'foo'],
+        ];
+    }
+
+    /**
      * @dataProvider provideBoolOptions
      */
     public function testGetBool(string $dsn, string $option, ?bool $expectedValue) : void

--- a/tests/Unit/DsnTest.php
+++ b/tests/Unit/DsnTest.php
@@ -205,6 +205,33 @@ final class DsnTest extends TestCase
     }
 
     /**
+     * @dataProvider provideFloatOptions
+     */
+    public function testGetFloat(string $dsn, string $option, $expectedValue) : void
+    {
+        $dsn = Dsn::parse($dsn);
+        self::assertSame($expectedValue, $dsn->getFloat($option));
+    }
+
+    public function provideFloatOptions() : iterable
+    {
+        return [
+            ['tcp://host/?foo=42.1', 'foo', 42.1],
+            ['tcp://host/?foo=0', 'foo', 0.0],
+            ['tcp://host', 'foo', null],
+            ['unix:///socket.sock/?foo=42.1', 'foo', 42.1],
+            ['unix:///socket.sock/?foo=0', 'foo', 0.0],
+            ['unix:///socket.sock', 'foo', null],
+        ];
+    }
+
+    public function testGetFloatDefault() : void
+    {
+        $dsn = Dsn::parse('tcp://host/?foo=2.2');
+        self::assertSame(42.1, $dsn->getFloat('baz', 42.1));
+    }
+
+    /**
      * @dataProvider provideBoolOptions
      */
     public function testGetBool(string $dsn, string $option, ?bool $expectedValue) : void


### PR DESCRIPTION
For highload projects 1 second is too long for a timeout. This simple change adds ability to set socket timeout as float. For example 0.1 is 100 miliseconds.