### PR TITLE
Extend authorization tests with new error message

### DIFF
--- a/tests/Integration/ClientMiddlewareTest.php
+++ b/tests/Integration/ClientMiddlewareTest.php
@@ -79,7 +79,7 @@ final class ClientMiddlewareTest extends TestCase
         ]);
 
         $this->expectException(RequestFailed::class);
-        $this->expectExceptionMessage("User 'ghost' is not found");
+        $this->expectExceptionMessageMatches("/(User 'ghost' is not found|User not found or supplied credentials are invalid)/");
 
         $client->ping();
     }

--- a/tests/Integration/Requests/AuthenticateTest.php
+++ b/tests/Integration/Requests/AuthenticateTest.php
@@ -50,7 +50,7 @@ final class AuthenticateTest extends TestCase
     /**
      * @dataProvider provideInvalidCredentials
      */
-    public function testAuthenticateWithInvalidCredentials(string $errorMessage, int $errorCode, $username, $password) : void
+    public function testAuthenticateWithInvalidCredentials(string $errorMessagePattern, $username, $password) : void
     {
         $client = ClientBuilder::createFromEnv()->setOptions([
             'username' => $username,
@@ -61,16 +61,15 @@ final class AuthenticateTest extends TestCase
             $client->ping();
             self::fail(sprintf('Client must throw an exception on authenticating "%s" with the password "%s"', $username, $password));
         } catch (RequestFailed $e) {
-            self::assertSame($errorMessage, $e->getMessage());
-            self::assertSame($errorCode, $e->getCode());
+            self::assertMatchesRegularExpression($errorMessagePattern, $e->getMessage());
         }
     }
 
     public function provideInvalidCredentials() : iterable
     {
         return [
-            ["User 'non_existing_user' is not found", 45, 'non_existing_user', 'password'],
-            ["Incorrect password supplied for user 'guest'", 47, 'guest', 'password'],
+            ["/(User 'non_existing_user' is not found|User not found or supplied credentials are invalid)/", 'non_existing_user', 'password'],
+            ["/(Incorrect password supplied for user 'guest'|User not found or supplied credentials are invalid)/", 'guest', 'password'],
         ];
     }
 


### PR DESCRIPTION
Tarantool is going to replace an error thrown in case of entering an invalid password and entering the login of a non-existent user during authorization. The patch updates authorization tests correspondingly.