### PR TITLE
Tarantool 3.0 SQL breaking change compatibility

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tests:
     env:
-      TNT_IMAGE: tarantool/tarantool:2.10
+      TNT_IMAGE: tarantool/tarantool:2.11
       PHP_IMAGE: php:8.2-cli
     strategy:
       fail-fast: false
@@ -65,6 +65,7 @@ jobs:
           - TNT_IMAGE: tarantool/tarantool:2.6
           - TNT_IMAGE: tarantool/tarantool:2.7
           - TNT_IMAGE: tarantool/tarantool:2.8
+          - TNT_IMAGE: tarantool/tarantool:2.10
 
     runs-on: ${{ matrix.operating-system }}
     steps:

--- a/examples/protocol/execute.php
+++ b/examples/protocol/execute.php
@@ -29,7 +29,15 @@ $result2 = $client->executeUpdate('
     [':email2' => 'bar@example.com']
 );
 
-$result3 = $client->executeQuery('SELECT * FROM users WHERE "email" = ?', 'foo@example.com');
+/**
+ * SEQSCAN keyword is explicitly allowing to use seqscan:
+ * https://github.com/tarantool/tarantool/commit/77648827326ad268ec0ffbcd620c2371b65ef2b4
+ * It was introduced in Tarantool 2.11.0-rc1. If compat.sql_seq_scan_default set to "new"
+ * (default value since 3.0), query returns error when trying to scan without keyword.
+ */
+$seqScan = server_version_at_least('2.11.0-rc1', $client) ? 'SEQSCAN' : '';
+$result3 = $client->executeQuery("SELECT * FROM $seqScan users WHERE \"email\" = ?", 'foo@example.com');
+
 $result4 = $client->executeQuery('SELECT * FROM users WHERE "id" IN (?, ?)', 1, 2);
 
 printf("Result 1: %s\n", json_encode([$result1->count(), $result1->getAutoincrementIds()]));

--- a/examples/protocol/prepare.php
+++ b/examples/protocol/prepare.php
@@ -27,7 +27,14 @@ for ($i = 1; $i <= 100; ++$i) {
 }
 $stmt->close();
 
-$result = $client->executeQuery('SELECT COUNT("id") AS "cnt" FROM users');
+/**
+ * SEQSCAN keyword is explicitly allowing to use seqscan:
+ * https://github.com/tarantool/tarantool/commit/77648827326ad268ec0ffbcd620c2371b65ef2b4
+ * It was introduced in Tarantool 2.11.0-rc1. If compat.sql_seq_scan_default set to "new"
+ * (default value since 3.0), query returns error when trying to scan without keyword.
+ */
+$seqScan = server_version_at_least('2.11.0-rc1', $client) ? 'SEQSCAN' : '';
+$result = $client->executeQuery("SELECT COUNT(\"id\") AS \"cnt\" FROM $seqScan users");
 
 printf("Result: %s\n", json_encode($result[0]));
 

--- a/tests/Integration/Requests/ExecuteTest.php
+++ b/tests/Integration/Requests/ExecuteTest.php
@@ -26,6 +26,17 @@ use Tarantool\Client\Tests\Integration\TestCase;
  */
 final class ExecuteTest extends TestCase
 {
+    private function provideSeqScan() : string
+    {
+        /**
+         * SEQSCAN keyword is explicitly allowing to use seqscan:
+         * https://github.com/tarantool/tarantool/commit/77648827326ad268ec0ffbcd620c2371b65ef2b4
+         * It was introduced in Tarantool 2.11.0-rc1. If compat.sql_seq_scan_default set to "new"
+         * (default value since 3.0), query returns error when trying to scan without keyword.
+         */
+        return $this->tarantoolVersionSatisfies('>=2.11.0-rc1') ? 'SEQSCAN' : '';
+    }
+
     /**
      * @sql DROP TABLE IF EXISTS exec_update
      * @sql CREATE TABLE exec_update (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(50))
@@ -47,7 +58,8 @@ final class ExecuteTest extends TestCase
 
     public function testExecuteFetchesAllRows() : void
     {
-        $response = $this->client->execute('SELECT * FROM exec_query');
+        $seqScan = self::provideSeqScan();
+        $response = $this->client->execute("SELECT * FROM $seqScan exec_query");
 
         self::assertSame([[1, 'A'], [2, 'B']], $response->getBodyField(Keys::DATA));
     }
@@ -94,7 +106,8 @@ final class ExecuteTest extends TestCase
 
     public function testExecuteQueryFetchesAllRows() : void
     {
-        $result = $this->client->executeQuery('SELECT * FROM exec_query');
+        $seqScan = self::provideSeqScan();
+        $result = $this->client->executeQuery("SELECT * FROM $seqScan exec_query");
 
         self::assertSame([[1, 'A'], [2, 'B']], $result->getData());
         self::assertSame(2, $result->count());
@@ -155,7 +168,8 @@ final class ExecuteTest extends TestCase
     {
         $client = ClientBuilder::createFromEnv()->build();
 
-        $response = $client->executeQuery('SELECT * FROM exec_query');
+        $seqScan = self::provideSeqScan();
+        $response = $client->executeQuery("SELECT * FROM $seqScan exec_query");
 
         self::assertSame([[
             Keys::METADATA_FIELD_NAME => 'ID',
@@ -178,7 +192,9 @@ final class ExecuteTest extends TestCase
         $client->execute('SET SESSION "sql_full_metadata" = true');
 
         $tableName = $this->resolvePlaceholders('%target_method%');
-        $response = $client->executeQuery("SELECT id, name as full_name FROM $tableName");
+
+        $seqScan = self::provideSeqScan();
+        $response = $client->executeQuery("SELECT id, name as full_name FROM $seqScan $tableName");
 
         self::assertSame([[
             Keys::METADATA_FIELD_NAME => 'ID',


### PR DESCRIPTION
### Add compatibility layer to SQL scan queries

Scanning SQL queries will be forbidden in Tarantool 3.0 by default [1]. To use them, `SEQSCAN` keyword must be specified before space name. One may also set `compat.sql_seq_scan_default` to `"old"`, but implicit scanning will be forbidden in future versions nonetheless.

Breaking change will be introduced in [2]. We need to merge this PR to PHP connector so [2] could pass integration tests before merge.

1. https://github.com/tarantool/tarantool/commit/77648827326ad268ec0ffbcd620c2371b65ef2b4
2. https://github.com/tarantool/tarantool/pull/8602

### Make Tarantool 2.11 the default image in CI

Tarantool 2.11 is an LTS release of Tarantool 2.x series.