### PR TITLE
errors: more verbose error reporting in `StreamConnection`

### DIFF
--- a/src/Exception/CommunicationFailed.php
+++ b/src/Exception/CommunicationFailed.php
@@ -15,4 +15,10 @@ namespace Tarantool\Client\Exception;
 
 final class CommunicationFailed extends \RuntimeException implements ClientException
 {
+    public static function withLastPhpError(string $errorMessage): self
+    {
+        $error = error_get_last();
+
+        return new self($error ? \sprintf("%s: %s", $errorMessage, $error['message']) : $errorMessage);
+    }
 }

--- a/tests/Integration/ClientMiddlewareTest.php
+++ b/tests/Integration/ClientMiddlewareTest.php
@@ -140,7 +140,7 @@ final class ClientMiddlewareTest extends TestCase
         $client->ping();
 
         $this->expectException(CommunicationFailed::class);
-        $this->expectExceptionMessage('Unable to write request');
+        $this->expectExceptionMessage('Error writing request: fwrite(): Send of 15 bytes failed with errno=32 Broken pipe');
         $client->ping();
     }
 

--- a/tests/Integration/Connection/ConnectionTest.php
+++ b/tests/Integration/Connection/ConnectionTest.php
@@ -190,12 +190,13 @@ final class ConnectionTest extends TestCase
     public function testOpenConnectionHandlesTheMissingGreetingCorrectly() : void
     {
         $clientBuilder = ClientBuilder::createForFakeServer();
+        $uri = $clientBuilder->getUri();
 
         FakeServerBuilder::create(
             new AtConnectionHandler(1, new WriteHandler('')),
             new AtConnectionHandler(2, new WriteHandler(GreetingDataProvider::generateGreeting()))
         )
-            ->setUri($clientBuilder->getUri())
+            ->setUri($uri)
             ->start();
 
         $client = $clientBuilder->build();
@@ -205,7 +206,11 @@ final class ConnectionTest extends TestCase
             $connection->open();
             self::fail('Connection not established');
         } catch (CommunicationFailed $e) {
-            self::assertSame('Unable to read greeting', $e->getMessage());
+            self::assertSame(
+                sprintf('Error reading greeting: ' .
+                    'stream_socket_client(): Unable to connect to %s ' .
+                    '(Connection refused)', $uri)
+                , $e->getMessage());
             // At that point the connection was successfully established,
             // but the greeting message was not read
         }

--- a/tests/Integration/Connection/ParseGreetingTest.php
+++ b/tests/Integration/Connection/ParseGreetingTest.php
@@ -27,9 +27,10 @@ final class ParseGreetingTest extends TestCase
     public function testParseGreetingWithInvalidServerName(string $greeting) : void
     {
         $clientBuilder = ClientBuilder::createForFakeServer();
+        $uri = $clientBuilder->getUri();
 
         FakeServerBuilder::create(new WriteHandler($greeting))
-            ->setUri($clientBuilder->getUri())
+            ->setUri($uri)
             ->start();
 
         $client = $clientBuilder->build();
@@ -37,7 +38,11 @@ final class ParseGreetingTest extends TestCase
         try {
             $client->ping();
         } catch (CommunicationFailed $e) {
-            self::assertSame('Unable to read greeting', $e->getMessage());
+            self::assertSame(
+                sprintf("Error reading greeting: " .
+                    "stream_socket_client(): Unable to connect to %s " .
+                    "(Connection refused)", $uri),
+                $e->getMessage());
 
             return;
         } catch (\RuntimeException $e) {

--- a/tests/Integration/Connection/ReadTest.php
+++ b/tests/Integration/Connection/ReadTest.php
@@ -35,15 +35,20 @@ final class ReadTest extends TestCase
     public function testReadEmptyGreeting() : void
     {
         $clientBuilder = ClientBuilder::createForFakeServer();
+        $uri = $clientBuilder->getUri();
 
         FakeServerBuilder::create()
-            ->setUri($clientBuilder->getUri())
+            ->setUri($uri)
             ->start();
 
         $client = $clientBuilder->build();
 
         $this->expectException(CommunicationFailed::class);
-        $this->expectExceptionMessage('Unable to read greeting');
+        $this->expectExceptionMessage(
+            \sprintf('Error reading greeting: ' .
+                     'stream_socket_client(): Unable to connect to %s ' .
+                     '(Connection refused)', $uri)
+        );
 
         $client->ping();
     }
@@ -51,18 +56,23 @@ final class ReadTest extends TestCase
     public function testUnableToReadResponseLength() : void
     {
         $clientBuilder = ClientBuilder::createForFakeServer();
+        $uri = $clientBuilder->getUri();
 
         FakeServerBuilder::create(
             new WriteHandler(GreetingDataProvider::generateGreeting()),
             new SleepHandler(1)
         )
-            ->setUri($clientBuilder->getUri())
+            ->setUri($uri)
             ->start();
 
         $client = $clientBuilder->build();
 
         $this->expectException(CommunicationFailed::class);
-        $this->expectExceptionMessage('Unable to read response length');
+        $this->expectExceptionMessage(
+            \sprintf('Error reading response length: ' .
+                'stream_socket_client(): Unable to connect to %s ' .
+                '(Connection refused)', $uri)
+        );
 
         $client->ping();
     }
@@ -90,19 +100,24 @@ final class ReadTest extends TestCase
     public function testUnableToReadResponse() : void
     {
         $clientBuilder = ClientBuilder::createForFakeServer();
+        $uri = $clientBuilder->getUri();
 
         FakeServerBuilder::create(
             new WriteHandler(GreetingDataProvider::generateGreeting()),
             new WriteHandler(PacketLength::pack(42)),
             new SleepHandler(1)
         )
-            ->setUri($clientBuilder->getUri())
+            ->setUri($uri)
             ->start();
 
         $client = $clientBuilder->build();
 
         $this->expectException(CommunicationFailed::class);
-        $this->expectExceptionMessage('Unable to read response');
+        $this->expectExceptionMessage(
+            \sprintf('Error reading response: ' .
+                'stream_socket_client(): Unable to connect to %s ' .
+                '(Connection refused)', $uri)
+        );
 
         $client->ping();
     }


### PR DESCRIPTION
This patch makes error reporting in `read` and `send` methods of `StreamConnection` more verbose to provide aid in debugging network errors.