### PR TITLE
test: fix tests on PHP 7

### DIFF
--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -151,7 +151,7 @@ final class StreamConnection implements Connection
         }
 
         if (!\fwrite($this->stream, $data)) {
-            throw CommunicationFailed::withLastPhpError("Error writing request");
+            throw CommunicationFailed::withLastPhpError('Error writing request');
         }
 
         $length = $this->read(PacketLength::SIZE_BYTES, 'Error reading response length');
@@ -172,7 +172,6 @@ final class StreamConnection implements Connection
         if ($meta['timed_out']) {
             throw new CommunicationFailed('Read timed out');
         }
-
 
         throw CommunicationFailed::withLastPhpError($errorMessage);
     }

--- a/src/Exception/CommunicationFailed.php
+++ b/src/Exception/CommunicationFailed.php
@@ -15,10 +15,10 @@ namespace Tarantool\Client\Exception;
 
 final class CommunicationFailed extends \RuntimeException implements ClientException
 {
-    public static function withLastPhpError(string $errorMessage): self
+    public static function withLastPhpError(string $errorMessage) : self
     {
-        $error = error_get_last();
+        $error = \error_get_last();
 
-        return new self($error ? \sprintf("%s: %s", $errorMessage, $error['message']) : $errorMessage);
+        return new self($error ? \sprintf('%s: %s', $errorMessage, $error['message']) : $errorMessage);
     }
 }

--- a/tests/Integration/ClientMiddlewareTest.php
+++ b/tests/Integration/ClientMiddlewareTest.php
@@ -139,9 +139,18 @@ final class ClientMiddlewareTest extends TestCase
 
         $client->ping();
 
-        $this->expectException(CommunicationFailed::class);
-        $this->expectExceptionMessage('Error writing request: fwrite(): Send of 15 bytes failed with errno=32 Broken pipe');
-        $client->ping();
+        try {
+            $client->ping();
+        } catch (CommunicationFailed $e) {
+            self::assertEqualsIgnoringCase(
+                'Error writing request: fwrite(): Send of 15 bytes failed with errno=32 Broken pipe',
+                $e->getMessage()
+            );
+
+            return;
+        }
+
+        self::fail();
     }
 
     private static function createBrokenConnectionMiddleware() : Middleware

--- a/tests/Integration/Connection/ConnectionTest.php
+++ b/tests/Integration/Connection/ConnectionTest.php
@@ -206,11 +206,12 @@ final class ConnectionTest extends TestCase
             $connection->open();
             self::fail('Connection not established');
         } catch (CommunicationFailed $e) {
-            self::assertSame(
-                sprintf('Error reading greeting: ' .
-                    'stream_socket_client(): Unable to connect to %s ' .
-                    '(Connection refused)', $uri)
-                , $e->getMessage());
+            self::assertStringContainsStringIgnoringCase(
+                \sprintf('Error reading greeting: '.
+                    'stream_socket_client(): Unable to connect to %s',
+                    $uri),
+                $e->getMessage()
+            );
             // At that point the connection was successfully established,
             // but the greeting message was not read
         }

--- a/tests/Integration/Connection/ParseGreetingTest.php
+++ b/tests/Integration/Connection/ParseGreetingTest.php
@@ -38,11 +38,12 @@ final class ParseGreetingTest extends TestCase
         try {
             $client->ping();
         } catch (CommunicationFailed $e) {
-            self::assertSame(
-                sprintf("Error reading greeting: " .
-                    "stream_socket_client(): Unable to connect to %s " .
-                    "(Connection refused)", $uri),
-                $e->getMessage());
+            self::assertStringContainsStringIgnoringCase(
+                sprintf('Error reading greeting: '.
+                    'stream_socket_client(): Unable to connect to %s ',
+                    $uri),
+                $e->getMessage()
+            );
 
             return;
         } catch (\RuntimeException $e) {

--- a/tests/Integration/Connection/ReadTest.php
+++ b/tests/Integration/Connection/ReadTest.php
@@ -43,14 +43,20 @@ final class ReadTest extends TestCase
 
         $client = $clientBuilder->build();
 
-        $this->expectException(CommunicationFailed::class);
-        $this->expectExceptionMessage(
-            \sprintf('Error reading greeting: ' .
-                     'stream_socket_client(): Unable to connect to %s ' .
-                     '(Connection refused)', $uri)
-        );
+        try {
+            $client->ping();
+        } catch (CommunicationFailed $e) {
+            self::assertStringContainsStringIgnoringCase(
+                \sprintf('Error reading greeting: '.
+                    'stream_socket_client(): Unable to connect to %s ',
+                    $uri),
+                $e->getMessage()
+            );
 
-        $client->ping();
+            return;
+        }
+
+        self::fail();
     }
 
     public function testUnableToReadResponseLength() : void
@@ -67,14 +73,20 @@ final class ReadTest extends TestCase
 
         $client = $clientBuilder->build();
 
-        $this->expectException(CommunicationFailed::class);
-        $this->expectExceptionMessage(
-            \sprintf('Error reading response length: ' .
-                'stream_socket_client(): Unable to connect to %s ' .
-                '(Connection refused)', $uri)
-        );
+        try {
+            $client->ping();
+        } catch (CommunicationFailed $e) {
+            self::assertStringContainsStringIgnoringCase(
+                \sprintf('Error reading response length: '.
+                    'stream_socket_client(): Unable to connect to %s ',
+                    $uri),
+                $e->getMessage()
+            );
 
-        $client->ping();
+            return;
+        }
+
+        self::fail();
     }
 
     public function testReadResponseLengthTimedOut() : void
@@ -112,14 +124,20 @@ final class ReadTest extends TestCase
 
         $client = $clientBuilder->build();
 
-        $this->expectException(CommunicationFailed::class);
-        $this->expectExceptionMessage(
-            \sprintf('Error reading response: ' .
-                'stream_socket_client(): Unable to connect to %s ' .
-                '(Connection refused)', $uri)
-        );
+        try {
+            $client->ping();
+        } catch (CommunicationFailed $e) {
+            self::assertStringContainsStringIgnoringCase(
+                \sprintf('Error reading response: '.
+                    'stream_socket_client(): Unable to connect to %s ',
+                    $uri),
+                $e->getMessage()
+            );
 
-        $client->ping();
+            return;
+        }
+
+        self::fail();
     }
 
     public function testSocketReadTimedOut() : void


### PR DESCRIPTION
Changes to tests introduced in #89 make them fail on PHP 7.x. This patch fixes failing tests.