### PR TITLE
test: fix Tarantool version for ACCESS_DENIED user field check

### DIFF
--- a/tests/Integration/BoxErrorTest.php
+++ b/tests/Integration/BoxErrorTest.php
@@ -64,7 +64,7 @@ final class BoxErrorTest extends TestCase
                 'access_type' => 'Write',
                 'user' => 'user_with_no_privileges',
             ];
-            if ($this->tarantoolVersionSatisfies('<= 3.0')) {
+            if ($this->tarantoolVersionSatisfies('< 3.1')) {
                 unset($expectedFields['user']);
             }
             self::assertEquals($expectedFields, $error->getFields());


### PR DESCRIPTION
Currently this test fails in Tarantool 3.0 branch.

Need for https://github.com/tarantool/tarantool/issues/9108